### PR TITLE
Fix training Dockerfile and entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Unified SageMaker Containers
+
+This repository contains example Docker resources for custom training and serving on Amazon SageMaker.
+
+## Project Layout
+
+- **cld_container_setup** – Python package providing a unified framework for training and inference along with example handlers and tests.
+- **training** – Dockerfile and build script for the training container.
+- **serving** – Dockerfile and utilities for the inference container.
+
+## Building and Pushing Images
+
+Each component folder includes a `build_and_push.sh` script. A typical workflow is:
+
+```bash
+# From repository root
+cd cld_container_setup && ./build_and_push.sh <account-id> <region> unified-sagemaker-container
+```
+
+See `cld_container_setup/quickstart.md` for detailed steps and additional examples.
+
+## Running Unit Tests
+
+The Python tests are located under `cld_container_setup/tests` and can be executed with:
+
+```bash
+pytest
+```
+
+Ensure required dependencies such as `numpy`, `boto3` and the SageMaker SDK are installed before running the tests.

--- a/cld_container_setup/scripts/unified-entrypoint.py
+++ b/cld_container_setup/scripts/unified-entrypoint.py
@@ -75,6 +75,8 @@ def main():
         if command == "train":
             start_training()
         elif command == "serve":
+            for var in ("SM_TRAINING_ENV", "SM_USER_ARGS"):
+                os.environ.pop(var, None)
             start_model_server()
         else:
             # Execute custom command

--- a/serving/container/dockerd-entrypoint.py
+++ b/serving/container/dockerd-entrypoint.py
@@ -9,7 +9,8 @@ from sagemaker_inference import model_server
 
 
 def _retry_if_error(exception):
-    return isinstance(exception, CalledProcessError or OSError)
+    """Retry on process errors including OSError."""
+    return isinstance(exception, (CalledProcessError, OSError))
 
 
 @retry(stop_max_delay=1000 * 50, retry_on_exception=_retry_if_error)

--- a/training/docker/Dockerfile
+++ b/training/docker/Dockerfile
@@ -62,3 +62,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     LC_ALL=C.UTF-8
 
 ENV SAGEMAKER_TRAINING_MODULE custom_framework_training.training:main
+
+# Set working directory and default entrypoint for training jobs
+WORKDIR /opt/ml
+ENTRYPOINT ["python", "-m", "custom_framework_training.training"]
+CMD ["train"]


### PR DESCRIPTION
## Summary
- fix retry helper to catch `OSError`
- set entrypoint and CMD in the training Dockerfile
- drop large training env vars before launching the model server
- add project level README

## Testing
- `pytest tests/test-container.py -q` *(fails: ModuleNotFoundError: No module named 'unified_entrypoint')*

------
https://chatgpt.com/codex/tasks/task_e_6852867767fc832a99e9fc278f0ca962