### PR TITLE
Add scikit-learn tabular SageMaker container

### DIFF
--- a/sklearn_container/Dockerfile
+++ b/sklearn_container/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl vim && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+        scikit-learn pandas numpy joblib \
+        sagemaker-training sagemaker-inference
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+COPY scripts/ /opt/ml/code/
+WORKDIR /opt/ml/code
+
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["train.py"]

--- a/sklearn_container/README.md
+++ b/sklearn_container/README.md
@@ -1,0 +1,43 @@
+# Scikit-learn Tabular Container
+
+This sample Docker image provides a lightweight environment for training and serving scikit-learn models on Amazon SageMaker.  The same image can be used for both training jobs and inference endpoints.
+
+## Folder Structure
+
+```
+sklearn_container/
+├── Dockerfile             # Container definition
+├── entrypoint.sh          # Entrypoint handling train/serve
+├── scripts/
+│   ├── train.py           # Example training script
+│   └── inference.py       # Example inference script
+```
+
+## Build
+
+```bash
+docker build -t sklearn-sagemaker sklearn_container
+```
+
+## Train Locally
+
+```bash
+docker run --rm \
+  -e SM_MODE=train \
+  -v $(pwd)/sklearn_container/scripts:/opt/ml/code \
+  -v $(pwd)/data/train:/opt/ml/input/data/train \
+  -v $(pwd)/model:/opt/ml/model \
+  sklearn-sagemaker train.py
+```
+
+## Serve Locally
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e SM_MODE=serve \
+  -v $(pwd)/sklearn_container/scripts:/opt/ml/code \
+  -v $(pwd)/model:/opt/ml/model \
+  sklearn-sagemaker inference.py
+```
+
+When used with SageMaker, specify the training or inference script as the `entry_point` argument of the estimator or model object.

--- a/sklearn_container/entrypoint.sh
+++ b/sklearn_container/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+MODE="$1"
+if [ -z "$MODE" ]; then
+  MODE=${SM_MODE:-train}
+else
+  shift
+fi
+
+if [ "$MODE" = "serve" ] || [ "$MODE" = "inference" ]; then
+  SCRIPT=${1:-inference.py}
+  export SAGEMAKER_PROGRAM=$SCRIPT
+  exec serve
+else
+  SCRIPT=${1:-train.py}
+  export SAGEMAKER_PROGRAM=$SCRIPT
+  exec python -m sagemaker_training
+fi

--- a/sklearn_container/scripts/inference.py
+++ b/sklearn_container/scripts/inference.py
@@ -1,0 +1,27 @@
+import os
+import io
+import pandas as pd
+import joblib
+
+model = None
+
+def model_fn(model_dir):
+    global model
+    if model is None:
+        model_path = os.path.join(model_dir, 'model.joblib')
+        model = joblib.load(model_path)
+    return model
+
+def input_fn(request_body, request_content_type):
+    if request_content_type == 'text/csv':
+        return pd.read_csv(io.StringIO(request_body), header=None)
+    raise ValueError('Unsupported content type: ' + request_content_type)
+
+def predict_fn(input_data, model):
+    return model.predict(input_data)
+
+def output_fn(prediction, accept):
+    if accept == 'text/csv':
+        result = ','.join(str(x) for x in prediction)
+        return result, 'text/csv'
+    raise ValueError('Unsupported accept type: ' + accept)

--- a/sklearn_container/scripts/train.py
+++ b/sklearn_container/scripts/train.py
@@ -1,0 +1,22 @@
+import argparse
+import os
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+import joblib
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--train', type=str, default=os.environ.get('SM_CHANNEL_TRAIN', '/opt/ml/input/data/train'))
+    parser.add_argument('--model-dir', type=str, default=os.environ.get('SM_MODEL_DIR', '/opt/ml/model'))
+    args = parser.parse_args()
+
+    data_path = os.path.join(args.train, 'train.csv')
+    df = pd.read_csv(data_path)
+    X = df.drop('target', axis=1)
+    y = df['target']
+
+    model = LogisticRegression(max_iter=100)
+    model.fit(X, y)
+
+    model_path = os.path.join(args.model_dir, 'model.joblib')
+    joblib.dump(model, model_path)


### PR DESCRIPTION
## Summary
- add Dockerfile for a scikit-learn training/serving container
- provide entrypoint for switching between train and serve
- include example train.py and inference.py scripts
- add README with usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ee004368832abc69542e29749482